### PR TITLE
Update manifest json

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ export default defineConfig({
 - What you add to your app is a **front-end–only** development tool: the Vite plugin + Babel transforms and the async event-tracking runtime (`fetch`, `async/await`, `useEffect`). Tracked events are forwarded to the Track-React DevTools panel when the extension is installed.
 - There is **no backend** component. You **do not** need to run any additional servers during development—just run your app and open the Track-React panel in DevTools.
 - Keep it as a **dev dependency** and enable `trackReactPlugin()` in your Vite config. The plugin declares `vite` as a peer dependency.
+
 ### Code Transformation
 
 Track-react uses Babel plugins to transform your code during development:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ export default defineConfig({
 
 ## 🔧 How It Works
 
+### Runtime Model & Packaging
+
+- Running `npm install track-react --save-dev` installs **only the published Vite plugin package** (from this repo’s `vite-plugin/`), not the entire repository and **not** the Chrome DevTools extension UI.
+- The npm package ships the **compiled build from `vite-plugin/dist/`** plus lightweight **runtime helpers** from `vite-plugin/runtime/`. These are the only files included via the package’s `"files"` field and surfaced through its `"exports"` map.
+- What you add to your app is a **front-end–only** development tool: the Vite plugin + Babel transforms and the async event-tracking runtime (`fetch`, `async/await`, `useEffect`). Tracked events are forwarded to the Track-React DevTools panel when the extension is installed.
+- There is **no backend** component. You **do not** need to run any additional servers during development—just run your app and open the Track-React panel in DevTools.
+- Keep it as a **dev dependency** and enable `trackReactPlugin()` in your Vite config. The plugin declares `vite` as a peer dependency.
 ### Code Transformation
 
 Track-react uses Babel plugins to transform your code during development:

--- a/devtools/manifest.json
+++ b/devtools/manifest.json
@@ -1,22 +1,20 @@
 {
   "name": "track-react",
-  "version": "1.0",
+  "version": "1.0.0",
   "manifest_version": 3,
-  "description": "Custom DevTools panel using React and Vite",
-  "devtools_page": "./devtools.html",
-
+  "description": "DevTools panel that displays messages bridged from window.postMessage.",
+  "devtools_page": "devtools.html",
   "background": {
     "service_worker": "background.js",
     "type": "module"
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": [
+        "http://localhost/*",
+        "https://localhost/*"
+      ],
       "js": ["content.js"]
     }
-  ],
-  "permissions": ["scripting"],
-  "action": {
-    "default_title": "track-react DevTools"
-  }
+  ]
 }

--- a/vite-plugin/package.json
+++ b/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "track-react",
-  "version": "0.0.5",
+  "version": "0.0.9",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -26,20 +26,21 @@
     "dist",
     "runtime"
   ],
-  "dependencies": {
+  "peerDependencies": {
+    "vite": "^4.0.0 || ^5.0.0 || ^7.0.0",
+    "@babel/core": "^7.28.0",
+    "@babel/plugin-syntax-jsx": "^7.27.1",
+    "@babel/plugin-syntax-typescript": "^7.27.1"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.0",
+    "typescript": "^5.4.5",
+    "vite": "^7.0.0",
     "@babel/core": "^7.28.0",
     "@babel/plugin-syntax-jsx": "^7.27.1",
     "@babel/plugin-syntax-typescript": "^7.27.1",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1"
-  },
-  "peerDependencies": {
-    "vite": "^4.0.0 || ^5.0.0 || ^7.0.0"
-  },
-  "devDependencies": {
-    "tsup": "^8.5.0",
-    "typescript": "^5.4.5",
-    "vite": "^7.0.0"
   },
   "scripts": {
     "build": "tsup"

--- a/vite-plugin/tsup.config.ts
+++ b/vite-plugin/tsup.config.ts
@@ -21,8 +21,8 @@ export default defineConfig({
   // ④ node target (affects down‑leveling)
   target: 'node18',
 
-  // ⑤ leave these deps unbundled
-  noExternal: [
+  // ⑤ leave these deps unbundled (external means they won't be bundled)
+  external: [
     'vite',
     '@babel/core',
     '@babel/plugin-syntax-jsx',
@@ -30,7 +30,7 @@ export default defineConfig({
     'fs',
     'path',
   ],
-
+  
   tsconfig: 'tsconfig.json',
 
   //⑥ run after build succeeds


### PR DESCRIPTION
update manifest.json to indicate the only function of the chrome extension is to receive messages from window.postMessage via the chrome.runtime api; update readme to include the Runtime Model & Packaging section which explains what parts of the repo i.e. vite-plugin are actually installed, also elaborates on front-end functionality i.e. no additional servers are required in development; fix fs dynamic require issue in tsup.config.ts by changing noExternal to external